### PR TITLE
Write the name of the migration that caused the error

### DIFF
--- a/App/Program.cs
+++ b/App/Program.cs
@@ -176,6 +176,7 @@ CREATE TABLE ""public"".MigrationRuns (
                 }
                 catch (Exception ex)
                 {
+                    Console.Error.WriteLine($"Error - {file}");
                     Console.Error.WriteLine(ex.ToString());
                     return false;
                 }


### PR DESCRIPTION
When a migration fails, the exception is written to stderr, but not the name of the migration that failed. This makes it harder to understand which migration is the source of the problem. The output is even misleading because the line before the exception has the name of the previous migration, often confusing users into thinking that the error came from that file:

```
Skipped - C:\src\000-good.sql
Skipped - C:\src\001-also-good.sql
System.Data.SqlClient.SqlException (0x80131904): Incorrect syntax near .....
```

This change adds a line with the migration name before writing the exception, so that it is clear which file was the cause of the error:

```
Skipped - C:\src\000-good.sql
Skipped - C:\src\001-also-good.sql
Error - C:\src\002-bad.sql
System.Data.SqlClient.SqlException (0x80131904): Incorrect syntax near .....
```

