### PR TITLE
Add strict encoding verification option

### DIFF
--- a/App/Config.cs
+++ b/App/Config.cs
@@ -18,6 +18,7 @@ namespace Badgie.Migrator
         public bool UseTransaction { get; set; } = true;
         public bool Verbose { get; set; } = false;
         public bool StackTraces {get; set; } = true;
+        public bool StrictEncoding {get; set; } = false;
 
         public List<Config> Configurations { get; set; }
 
@@ -38,13 +39,14 @@ namespace Badgie.Migrator
 
             if (args == null || args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
             {
-                Console.Error.WriteLine(@"Usage: dotnet-badgie-migrator <connection string> [drive:][path][filename] [-d:(SqlServer|Postgres|MySql)] [-f] [-i] [-n] [-V] [--no-stack-trce]
+                Console.Error.WriteLine(@"Usage: dotnet-badgie-migrator <connection string> [drive:][path][filename] [-d:(SqlServer|Postgres|MySql)] [-f] [-i] [-n] [-V] [--no-stack-trace] [--strict-encoding]
 -f                      runs mutated migrations
 -i                      if needed, installs the db table needed to store state
 -d:(SqlServer|Postgres) specifies whether to run against SQL Server, PostgreSQL or MySql
 -n                      avoids wrapping each execution in a transaction
 -V                      Verbose mode: executes with tracing
 --no-stack-trace        Omit the (mostly useless) stack traces
+--strict-encoding       Refuse to run migrations containing invalid characters
 
 Alternative usage: dotnet-badgie-migrator -json=filename
 -json                   path to a json file that contains a array of configurations 
@@ -58,15 +60,19 @@ Alternative usage: dotnet-badgie-migrator -json=filename
                             ""Install"": true|false,
                             ""SqlType"": ""SqlServer""|""Postgres""|""MySql"",
                             ""Path"": ""<path to migrations with wildcards>"",
-                            ""UseTransaction"": true|false
-                          },                      
+                            ""UseTransaction"": true|false,
+                            ""StackTraces"": true|false,
+                            ""StrictEncoding"": true|false
+                          },
                           {
                             ""ConnectionString"": <connection string>,
                             ""Force"": true|false,
                             ""Install"": true|false,
                             ""SqlType"": ""SqlServer""|""Postgres""|""MySql"",
                             ""Path"": ""<path to migrations with wildcards>"",
-                            ""UseTransaction"": true|false
+                            ""UseTransaction"": true|false,
+                            ""StackTraces"": true|false,
+                            ""StrictEncoding"": true|false
                           }
                         ]");
                 return null;
@@ -100,6 +106,10 @@ Alternative usage: dotnet-badgie-migrator -json=filename
                         {
                             case "no-stack-trace":
                                 config.StackTraces = false;
+                                break;
+
+                            case "strict-encoding":
+                                config.StrictEncoding = true;
                                 break;
                         }
                         break;


### PR DESCRIPTION
Adds a new argument, `--strict-encoding`, that prevents executing migrations containing invalid characters.

## Motivation

When developers create migrations, they sometimes forget to save the file in UTF-8. If the file contains non-ASCII characters, its interpretation depends on the current locale and also on the platform. Because Badgie always converts the migration script to UTF-8 before calculating the file hash, it may get different hashes on different machines.

Having non-ASCII characters in a file that is not encoded in UTF-8 is problematic anyway because those characters may be interpreted differently than intended.

Note that files that contain byte order marks are not affected by this issue, as .NET detects those and selects the proper encoding.

## Implementation

When reading a text file, .NET will attempt to read it as UTF-8, unless it detects a byte order mark. While reading as UTF-8, any character that cannot be decoded is handled by `Encoding.UTF8.DecoderFallback`, which inserts the `'\xFFFD'` character instead.

We add a new configuration argument, called `--strict-encoding`. When set, before executing a migration, Badgie checks if the migration contains the fallback character. If it is found, an exception is thrown with an error message that indicates the problem, similar to this:
```
Error - C:\migrations\123-badly-encoded-migration.sql
Found an invalid character at offset 30923:
    |         SET @max = CEILING( @MaxIDCoupon/CAST(@step AS FLOAT))*@step --ultimo numero, comopreso (se lo step ? corretto)
    |                                                                                                             ^
Please make sure that the encoding of the file is correct (UTF-8 is recommended).

Execution error
```

The encoding is only validated before executing the migration because it is possible that an existing migration had this problem, but since it was already executed, throwing an error would not be helpful, as the developer would be forced to modify the migration, making the adoption of this parameter more difficult.
