### PR TITLE
update npgsql version

### DIFF
--- a/App/badgie-migrator.csproj
+++ b/App/badgie-migrator.csproj
@@ -35,7 +35,7 @@
 		<PackageReference Include="Dapper" Version="1.60.9" />
 		<PackageReference Include="MySql.Data" Version="8.0.31" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Npgsql" Version="4.0.7" />
+		<PackageReference Include="Npgsql" Version="8.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="icon.png">


### PR DESCRIPTION
Update npgsql version from 4.0.7 to 8.0.1. The old version in some circumstances can fail to handle a valid postgres connection string behind a ssh tunnel.