### PR TITLE
Use explicit vm image version to support .net 9 during builds.

### DIFF
--- a/App/badgie-migrator.csproj
+++ b/App/badgie-migrator.csproj
@@ -6,7 +6,7 @@
 		<ToolCommandName>dotnet-badgie-migrator</ToolCommandName>
 		<PackageId>Badgie.Migrator</PackageId>
 		<PackageType>DotNetCliTool</PackageType>
-		<TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<Authors>Marco Cecconi et al.</Authors>
 		<Company>Intelligent Hack</Company>
 		<PackageTags>migrations;migrator;sql-server;sqlserver;postgres;pg;postgresql;schema migrations;mysql</PackageTags>

--- a/Tests/Badgie.Migrator.Tests.csproj
+++ b/Tests/Badgie.Migrator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-22.04'
 
 variables:
   buildConfiguration: 'Release'


### PR DESCRIPTION
Attempt to fix the build process, according to this: https://github.com/actions/runner-images/issues/11965#issuecomment-2816699571

