### PR TITLE
Add dotnet 9 installation to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,10 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: UseDotNet@2
+  inputs:
+    packageType: sdk
+    version: '9.0.x'
 - script: dotnet build --configuration $(buildConfiguration)
   displayName: 'dotnet build'
 - script: dotnet test --configuration $(buildConfiguration)


### PR DESCRIPTION
## Summary
- install dotnet SDK 9.0.x before the build

## Testing
- `dotnet test Tests/Badgie.Migrator.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6856b502f138832d9fd41d03e1c0226b