### PR TITLE
Fix GO split regex

### DIFF
--- a/App/Program.cs
+++ b/App/Program.cs
@@ -315,7 +315,7 @@ CREATE TABLE `migration_runs` (
             return MigrationResult.Run;
         }
 
-        private static readonly Regex Splitter = new Regex(@"\nGO\s?\n", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        private static readonly Regex Splitter = new Regex(@"\n\s*GO\s*\n", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
         private static readonly string InvalidCharFallback = ((DecoderReplacementFallback)Encoding.UTF8.DecoderFallback).DefaultString;
 
         public static void RunFile(string sql, Config config)

--- a/Tests/SplitterTests.cs
+++ b/Tests/SplitterTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Badgie.Migrator.Tests
+{
+    public class SplitterTests
+    {
+        private static Regex GetSplitter()
+        {
+            var field = typeof(Program).GetField("Splitter", BindingFlags.NonPublic | BindingFlags.Static);
+            return (Regex)field.GetValue(null);
+        }
+
+        [TestCase("\nGO\n")]
+        [TestCase("\nGO \n")]
+        [TestCase("\n  GO\n")]
+        [TestCase("\n  GO  \n")]
+        [TestCase("\n\tGO\t\n")]
+        public void SplitterAcceptsWhitespaceAroundGo(string delimiter)
+        {
+            var splitter = GetSplitter();
+            var sql = $"SELECT 1{delimiter}SELECT 2";
+            var parts = splitter.Split(sql);
+            Assert.AreEqual(2, parts.Length);
+            Assert.AreEqual("SELECT 1", parts[0].Trim());
+            Assert.AreEqual("SELECT 2", parts[1].Trim());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow whitespace around `GO` delimiter
- test regex splitting with a variety of whitespace

## Testing
- `dotnet test` 

------
https://chatgpt.com/codex/tasks/task_e_6856b8d7bb98832d8a02080f6fe93f06