### PR TITLE
Fix build with .NET 8

### DIFF
--- a/App/badgie-migrator.csproj
+++ b/App/badgie-migrator.csproj
@@ -6,7 +6,7 @@
 		<ToolCommandName>dotnet-badgie-migrator</ToolCommandName>
 		<PackageId>Badgie.Migrator</PackageId>
 		<PackageType>DotNetCliTool</PackageType>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<Authors>Marco Cecconi et al.</Authors>
 		<Company>Intelligent Hack</Company>
 		<PackageTags>migrations;migrator;sql-server;sqlserver;postgres;pg;postgresql;schema migrations;mysql</PackageTags>

--- a/Tests/Badgie.Migrator.Tests.csproj
+++ b/Tests/Badgie.Migrator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-  "sdk": { "version": "9.0.x" }
+  "sdk": { "version": "8.0.x" }
 }


### PR DESCRIPTION
## Summary
- target .NET 8 in `global.json`
- remove `net9.0` from project frameworks

## Testing
- `dotnet test Badgie.Migrator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6856b8bb2a80832d94f22c33c4d43f07