### PR TITLE
Fix typo in usage text

### DIFF
--- a/App/Config.cs
+++ b/App/Config.cs
@@ -49,7 +49,7 @@ namespace Badgie.Migrator
 --strict-encoding       Refuse to run migrations containing invalid characters
 
 Alternative usage: dotnet-badgie-migrator -json=filename
--json                   path to a json file that contains a array of configurations 
+-json                   path to a json file that contains an array of configurations 
                         which will be executed in order.
 
                         Example json configuration file:


### PR DESCRIPTION
## Summary
- fix typo in App usage text: "a array" -> "an array"

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dcac7798832d851d5c50cb4a7ee6