### PR TITLE
Add -s:<schema> parameter for migration tracking table

### DIFF
--- a/App/Config.cs
+++ b/App/Config.cs
@@ -19,6 +19,7 @@ namespace Badgie.Migrator
         public bool Verbose { get; set; } = false;
         public bool StackTraces {get; set; } = true;
         public bool StrictEncoding {get; set; } = false;
+        public string Schema { get; set; }
 
         public List<Config> Configurations { get; set; }
 
@@ -39,10 +40,13 @@ namespace Badgie.Migrator
 
             if (args == null || args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
             {
-                Console.Error.WriteLine(@"Usage: dotnet-badgie-migrator <connection string> [drive:][path][filename] [-d:(SqlServer|Postgres|MySql)] [-f] [-i] [-n] [-V] [--no-stack-trace] [--strict-encoding]
+                Console.Error.WriteLine(@"Usage: dotnet-badgie-migrator <connection string> [drive:][path][filename] [-d:(SqlServer|Postgres|MySql|SQLite)] [-f] [-i] [-n] [-s:<schema>] [-V] [--no-stack-trace] [--strict-encoding]
 -f                      runs mutated migrations
 -i                      if needed, installs the db table needed to store state
--d:<type>               specifies whether to run against SQL Server, PostgreSQL or MySql
+-d:<type>               specifies whether to run against SQL Server, PostgreSQL, MySql or SQLite
+-s:<schema>             specifies the schema for the migration tracking table
+                        (e.g. -s:myschema). Defaults: 'public' (Postgres), 'dbo' (SQL Server),
+                        'main' (SQLite), or connection default (MySQL)
 -n                      avoids wrapping each execution in a transaction
 -V                      Verbose mode: executes with tracing
 --no-stack-trace        Omit the (mostly useless) stack traces
@@ -58,17 +62,18 @@ Alternative usage: dotnet-badgie-migrator -json=filename
                             ""ConnectionString"": <connection string>,
                             ""Force"": true|false,
                             ""Install"": true|false,
-                            ""SqlType"": ""SqlServer""|""Postgres""|""MySql"",
+                            ""SqlType"": ""SqlServer""|""Postgres""|""MySql""|""SQLite"",
                             ""Path"": ""<path to migrations with wildcards>"",
                             ""UseTransaction"": true|false,
                             ""StackTraces"": true|false,
-                            ""StrictEncoding"": true|false
+                            ""StrictEncoding"": true|false,
+                            ""Schema"": ""<optional schema name>""
                           },
                           {
                             ""ConnectionString"": <connection string>,
                             ""Force"": true|false,
                             ""Install"": true|false,
-                            ""SqlType"": ""SqlServer""|""Postgres""|""MySql"",
+                            ""SqlType"": ""SqlServer""|""Postgres""|""MySql""|""SQLite"",
                             ""Path"": ""<path to migrations with wildcards>"",
                             ""UseTransaction"": true|false,
                             ""StackTraces"": true|false,
@@ -127,6 +132,14 @@ Alternative usage: dotnet-badgie-migrator -json=filename
                         }
 
                         config.SqlType = sqlType;
+                        break;
+
+                    case "-s":
+                        if (!str.StartsWith("-s:") || str.Length <= 3)
+                        {
+                            return null;
+                        }
+                        config.Schema = str[3..];
                         break;
 
                     case "-n":

--- a/App/Program.cs
+++ b/App/Program.cs
@@ -406,11 +406,9 @@ CREATE TABLE {schema}.MigrationRuns (
                 RunFile(sql, config);
                 using var conn = CreateConnection(config);
                 conn.Execute(config.Schema == null
-                    ? config.SqlType switch
-                    {
-                        SqlType.MySql => "update `migration_runs` set last_run = @LastRun, migration_result = @MigrationResult, md5 = @MD5 where filename = @Filename",
-                        _ => "update MigrationRuns set LastRun = @LastRun, MigrationResult = @MigrationResult, MD5 = @MD5 where Filename = @Filename"
-                    }
+                    ? (config.SqlType == SqlType.MySql
+                        ? "update `migration_runs` set last_run = @LastRun, migration_result = @MigrationResult, md5 = @MD5 where filename = @Filename"
+                        : "update MigrationRuns set LastRun = @LastRun, MigrationResult = @MigrationResult, MD5 = @MD5 where Filename = @Filename")
                     : config.SqlType switch
                     {
                         SqlType.MySql => $"update `{config.Schema}`.`migration_runs` set last_run = @LastRun, migration_result = @MigrationResult, md5 = @MD5 where filename = @Filename",

--- a/App/Program.cs
+++ b/App/Program.cs
@@ -29,6 +29,13 @@ namespace Badgie.Migrator
                 Environment.Exit(-2);
             }
 
+            if (_config.Schema == null)
+            {
+                Console.Error.WriteLine(
+                    "Warning: No -s:<schema> specified. The migration tracking table uses " +
+                    "the legacy default schema. In a future version, -s will be required.");
+            }
+
             if (_config.Configurations != null && _config.Configurations.Count > 1)
             {
                 if (_config.Verbose) Console.WriteLine("Info: {0} configurations found.", _config.Configurations.Count);
@@ -87,31 +94,62 @@ namespace Badgie.Migrator
             bool installed;
             using (var x = CreateConnection(config))
             {
-                switch (config.SqlType)
+                if (config.Schema == null)
                 {
-                    case SqlType.MySql:
-                        if (config.Verbose) Console.WriteLine("Info: verifying table on MySQL");
-                        installed = x.GetSchema("Tables", new string[] { null, x.Database, "migration_runs", null }).Rows.Count > 0;
-                        break;
+                    switch (config.SqlType)
+                    {
+                        case SqlType.MySql:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on MySQL");
+                            installed = x.GetSchema("Tables", new string[] { null, x.Database, "migration_runs", null }).Rows.Count > 0;
+                            break;
 
-                    case SqlType.Postgres:
-                        if (config.Verbose) Console.WriteLine("Info: verifying table on Postgres");
-                        installed = x.GetSchema("Tables", new string[] { null, "public", "migrationruns", null }).Rows.Count > 0;
-                        break;
+                        case SqlType.Postgres:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on Postgres");
+                            installed = x.GetSchema("Tables", new string[] { null, "public", "migrationruns", null }).Rows.Count > 0;
+                            break;
 
-                    case SqlType.SqlServer:
-                        if (config.Verbose) Console.WriteLine("Info: verifying table on SQL Server");
-                        installed = x.GetSchema("Tables", new string[] { null, "dbo", "MigrationRuns", null }).Rows.Count > 0;
-                        break;
+                        case SqlType.SqlServer:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on SQL Server");
+                            installed = x.GetSchema("Tables", new string[] { null, "dbo", "MigrationRuns", null }).Rows.Count > 0;
+                            break;
 
-                    case SqlType.SQLite:
-                        if (config.Verbose) Console.WriteLine("Info: verifying table on SQLite");
-                        installed = x.QueryFirstOrDefault<int>(
-                            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='MigrationRuns'") > 0;
-                        break;
+                        case SqlType.SQLite:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on SQLite");
+                            installed = x.GetSchema("Tables", new string[] { null, null, "MigrationRuns", null }).Rows.Count > 0;
+                            break;
 
-                    default:
-                        throw new NotSupportedException();
+                        default:
+                            throw new NotSupportedException();
+                    }
+                }
+                else
+                {
+                    var schema = config.Schema;
+                    switch (config.SqlType)
+                    {
+                        case SqlType.MySql:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on MySQL");
+                            installed = x.GetSchema("Tables", new string[] { null, schema, "migration_runs", null }).Rows.Count > 0;
+                            break;
+
+                        case SqlType.Postgres:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on Postgres");
+                            installed = x.GetSchema("Tables", new string[] { null, schema, "migrationruns", null }).Rows.Count > 0;
+                            break;
+
+                        case SqlType.SqlServer:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on SQL Server");
+                            installed = x.GetSchema("Tables", new string[] { null, schema, "MigrationRuns", null }).Rows.Count > 0;
+                            break;
+
+                        case SqlType.SQLite:
+                            if (config.Verbose) Console.WriteLine("Info: verifying table on SQLite");
+                            installed = x.GetSchema("Tables", new string[] { schema, null, "MigrationRuns", null }).Rows.Count > 0;
+                            break;
+
+                        default:
+                            throw new NotSupportedException();
+                    }
                 }
             }
             if (config.Verbose) Console.WriteLine(installed ? "Info: table found!" : "Info: table not found!");
@@ -182,10 +220,12 @@ namespace Badgie.Migrator
 
         private static string TableCreationStatement(Config config)
         {
-            switch (config.SqlType)
+            if (config.Schema == null)
             {
-                case SqlType.SqlServer:
-                    return @"
+                switch (config.SqlType)
+                {
+                    case SqlType.SqlServer:
+                        return @"
 CREATE TABLE [dbo].[MigrationRuns] (
     Id              INT             IDENTITY (1, 1) NOT NULL,
     LastRun         DATETIME        NOT NULL,
@@ -194,8 +234,8 @@ CREATE TABLE [dbo].[MigrationRuns] (
     MigrationResult TINYINT         NOT NULL,
     CONSTRAINT [PK_MigrationRuns] PRIMARY KEY CLUSTERED ([Id] ASC)
 );";
-                case SqlType.Postgres:
-                    return @"
+                    case SqlType.Postgres:
+                        return @"
 CREATE SEQUENCE MigrationRuns_Id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
 CREATE TABLE ""public"".MigrationRuns (
     Id integer DEFAULT nextval('MigrationRuns_Id_seq') NOT NULL,
@@ -205,8 +245,8 @@ CREATE TABLE ""public"".MigrationRuns (
     MigrationResult integer NOT NULL,
     CONSTRAINT ""MigrationRuns_Id"" PRIMARY KEY (Id)
 ) WITH (oids = false);";
-                case SqlType.MySql:
-                    return @"
+                    case SqlType.MySql:
+                        return @"
 CREATE TABLE `migration_runs` (
   `id` int NOT NULL AUTO_INCREMENT,
   `last_run` datetime NOT NULL,
@@ -215,8 +255,8 @@ CREATE TABLE `migration_runs` (
   `migration_result` tinyint NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;";
-                case SqlType.SQLite:
-                    return @"
+                    case SqlType.SQLite:
+                        return @"
 CREATE TABLE MigrationRuns (
     Id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     LastRun TEXT NOT NULL,
@@ -224,8 +264,58 @@ CREATE TABLE MigrationRuns (
     MD5 TEXT NOT NULL,
     MigrationResult INTEGER NOT NULL
 );";
-                default:
-                    throw new NotSupportedException();
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+            else
+            {
+                var schema = config.Schema;
+                switch (config.SqlType)
+                {
+                    case SqlType.SqlServer:
+                        return $@"
+CREATE TABLE [{schema}].[MigrationRuns] (
+    Id              INT             IDENTITY (1, 1) NOT NULL,
+    LastRun         DATETIME        NOT NULL,
+    Filename        NVARCHAR(2000)  NOT NULL,
+    MD5             VARCHAR(50)     NOT NULL,
+    MigrationResult TINYINT         NOT NULL,
+    CONSTRAINT [PK_MigrationRuns] PRIMARY KEY CLUSTERED ([Id] ASC)
+);";
+                    case SqlType.Postgres:
+                        return $@"
+CREATE SEQUENCE ""{schema}"".""MigrationRuns_Id_seq"" INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
+CREATE TABLE ""{schema}"".MigrationRuns (
+    Id integer DEFAULT nextval('""{schema}"".""MigrationRuns_Id_seq""') NOT NULL,
+    LastRun timestamp  NOT NULL,
+    Filename character varying(2000) NOT NULL,
+    MD5 character varying(50) NOT NULL,
+    MigrationResult integer NOT NULL,
+    CONSTRAINT ""MigrationRuns_Id"" PRIMARY KEY (Id)
+) WITH (oids = false);";
+                    case SqlType.MySql:
+                        return $@"
+CREATE TABLE `{schema}`.`migration_runs` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `last_run` datetime NOT NULL,
+  `filename` text NOT NULL,
+  `md5` varchar(50) NOT NULL,
+  `migration_result` tinyint NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;";
+                    case SqlType.SQLite:
+                        return $@"
+CREATE TABLE {schema}.MigrationRuns (
+    Id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    LastRun TEXT NOT NULL,
+    Filename TEXT NOT NULL,
+    MD5 TEXT NOT NULL,
+    MigrationResult INTEGER NOT NULL
+);";
+                    default:
+                        throw new NotSupportedException();
+                }
             }
         }
 
@@ -279,14 +369,25 @@ CREATE TABLE MigrationRuns (
             MigrationRun run;
             using (var conn = CreateConnection(config))
             {
-                run = conn.QueryFirstOrDefault<MigrationRun>(
-                    config.SqlType switch
-                    {
-                        SqlType.MySql => "select * from `migration_runs` where filename = @migrationFilename",
-                        _ => "select * from MigrationRuns where Filename = @migrationFilename"
-                    },
-                    new { migrationFilename = Path.GetFileName(migrationFilename) }
-                );
+                run = config.Schema == null
+                    ? conn.QueryFirstOrDefault<MigrationRun>(
+                        config.SqlType switch
+                        {
+                            SqlType.MySql => "select * from `migration_runs` where filename = @migrationFilename",
+                            _ => "select * from MigrationRuns where Filename = @migrationFilename"
+                        },
+                        new { migrationFilename = Path.GetFileName(migrationFilename) }
+                    )
+                    : conn.QueryFirstOrDefault<MigrationRun>(
+                        config.SqlType switch
+                        {
+                            SqlType.MySql => $"select * from `{config.Schema}`.`migration_runs` where filename = @migrationFilename",
+                            SqlType.Postgres => $@"select * from ""{config.Schema}"".""MigrationRuns"" where ""Filename"" = @migrationFilename",
+                            SqlType.SqlServer => $"select * from [{config.Schema}].[MigrationRuns] where Filename = @migrationFilename",
+                            _ => $"select * from {config.Schema}.MigrationRuns where Filename = @migrationFilename"
+                        },
+                        new { migrationFilename = Path.GetFileName(migrationFilename) }
+                    );
             }
 
             if (run != null)
@@ -304,12 +405,21 @@ CREATE TABLE MigrationRuns (
 
                 RunFile(sql, config);
                 using var conn = CreateConnection(config);
-                conn.Execute(config.SqlType switch
-                {
-                    SqlType.MySql => "update `migration_runs` set last_run = @LastRun, migration_result = @MigrationResult, md5 = @MD5 where filename = @Filename",
-                    _ => "update MigrationRuns set LastRun = @LastRun, MigrationResult = @MigrationResult, MD5 = @MD5 where Filename = @Filename"
+                conn.Execute(config.Schema == null
+                    ? config.SqlType switch
+                    {
+                        SqlType.MySql => "update `migration_runs` set last_run = @LastRun, migration_result = @MigrationResult, md5 = @MD5 where filename = @Filename",
+                        _ => "update MigrationRuns set LastRun = @LastRun, MigrationResult = @MigrationResult, MD5 = @MD5 where Filename = @Filename"
+                    }
+                    : config.SqlType switch
+                    {
+                        SqlType.MySql => $"update `{config.Schema}`.`migration_runs` set last_run = @LastRun, migration_result = @MigrationResult, md5 = @MD5 where filename = @Filename",
+                        SqlType.Postgres => $@"update ""{config.Schema}"".""MigrationRuns"" set ""LastRun"" = @LastRun, ""MigrationResult"" = @MigrationResult, ""MD5"" = @MD5 where ""Filename"" = @Filename",
+                        SqlType.SqlServer => $"update [{config.Schema}].[MigrationRuns] set LastRun = @LastRun, MigrationResult = @MigrationResult, MD5 = @MD5 where Filename = @Filename",
+                        _ => $"update {config.Schema}.MigrationRuns set LastRun = @LastRun, MigrationResult = @MigrationResult, MD5 = @MD5 where Filename = @Filename"
+                    }
 
-                }, new MigrationRun
+                , new MigrationRun
                 {
                     LastRun = DateTime.UtcNow,
                     Filename = Path.GetFileName(migrationFilename),
@@ -324,12 +434,21 @@ CREATE TABLE MigrationRuns (
             using (var conn = CreateConnection(config))
             {
                 if (config.Verbose) Console.WriteLine("Info: saving in migration table");
-                conn.Execute(config.SqlType switch
-                {
-                    SqlType.MySql => "insert into `migration_runs` (last_run, migration_result, md5, filename) values (@LastRun, @MigrationResult, @MD5, @Filename)",
-                    _ => "insert into MigrationRuns (LastRun, MigrationResult, MD5, Filename) values (@LastRun, @MigrationResult, @MD5, @Filename)"
+                conn.Execute(config.Schema == null
+                    ? config.SqlType switch
+                    {
+                        SqlType.MySql => "insert into `migration_runs` (last_run, migration_result, md5, filename) values (@LastRun, @MigrationResult, @MD5, @Filename)",
+                        _ => "insert into MigrationRuns (LastRun, MigrationResult, MD5, Filename) values (@LastRun, @MigrationResult, @MD5, @Filename)"
+                    }
+                    : config.SqlType switch
+                    {
+                        SqlType.MySql => $"insert into `{config.Schema}`.`migration_runs` (last_run, migration_result, md5, filename) values (@LastRun, @MigrationResult, @MD5, @Filename)",
+                        SqlType.Postgres => $@"insert into ""{config.Schema}"".""MigrationRuns"" (""LastRun"", ""MigrationResult"", ""MD5"", ""Filename"") values (@LastRun, @MigrationResult, @MD5, @Filename)",
+                        SqlType.SqlServer => $"insert into [{config.Schema}].[MigrationRuns] (LastRun, MigrationResult, MD5, Filename) values (@LastRun, @MigrationResult, @MD5, @Filename)",
+                        _ => $"insert into {config.Schema}.MigrationRuns (LastRun, MigrationResult, MD5, Filename) values (@LastRun, @MigrationResult, @MD5, @Filename)"
+                    }
 
-                }, new MigrationRun
+                , new MigrationRun
                 {
                     LastRun = DateTime.UtcNow,
                     Filename = Path.GetFileName(migrationFilename),

--- a/Tests/ConfigTests.cs
+++ b/Tests/ConfigTests.cs
@@ -281,7 +281,7 @@ namespace Badgie.Migrator.Tests
         [Test]
         public void SchemaParam()
         {
-            var args = new string[] { "connection", "-s:myschema" };
+            var args = new[] { "connection", "-s:myschema" };
             var config = Config.FromArgs(args);
             Assert.IsNotNull(config);
             Assert.AreEqual("myschema", config.Schema);
@@ -290,7 +290,7 @@ namespace Badgie.Migrator.Tests
         [Test]
         public void SchemaParamWithOtherFlags()
         {
-            var args = new string[] { "connection", "path", "-i", "-d:Postgres", "-s:scheduler" };
+            var args = new[] { "connection", "path", "-i", "-d:Postgres", "-s:scheduler" };
             var config = Config.FromArgs(args);
             Assert.IsNotNull(config);
             Assert.AreEqual("scheduler", config.Schema);
@@ -302,7 +302,7 @@ namespace Badgie.Migrator.Tests
         [Test]
         public void SchemaDefaultsToNull()
         {
-            var args = new string[] { "connection" };
+            var args = new[] { "connection" };
             var config = Config.FromArgs(args);
             Assert.IsNotNull(config);
             Assert.IsNull(config.Schema);
@@ -311,7 +311,7 @@ namespace Badgie.Migrator.Tests
         [Test]
         public void SchemaEmptyValueReturnsNull()
         {
-            var args = new string[] { "connection", "-s:" };
+            var args = new[] { "connection", "-s:" };
             var config = Config.FromArgs(args);
             Assert.IsNull(config);
         }

--- a/Tests/ConfigTests.cs
+++ b/Tests/ConfigTests.cs
@@ -278,6 +278,44 @@ namespace Badgie.Migrator.Tests
         }
 
 
+        [Test]
+        public void SchemaParam()
+        {
+            var args = new string[] { "connection", "-s:myschema" };
+            var config = Config.FromArgs(args);
+            Assert.IsNotNull(config);
+            Assert.AreEqual("myschema", config.Schema);
+        }
+
+        [Test]
+        public void SchemaParamWithOtherFlags()
+        {
+            var args = new string[] { "connection", "path", "-i", "-d:Postgres", "-s:scheduler" };
+            var config = Config.FromArgs(args);
+            Assert.IsNotNull(config);
+            Assert.AreEqual("scheduler", config.Schema);
+            Assert.AreEqual(true, config.Install);
+            Assert.AreEqual(SqlType.Postgres, config.SqlType);
+            Assert.AreEqual("path", config.Path);
+        }
+
+        [Test]
+        public void SchemaDefaultsToNull()
+        {
+            var args = new string[] { "connection" };
+            var config = Config.FromArgs(args);
+            Assert.IsNotNull(config);
+            Assert.IsNull(config.Schema);
+        }
+
+        [Test]
+        public void SchemaEmptyValueReturnsNull()
+        {
+            var args = new string[] { "connection", "-s:" };
+            var config = Config.FromArgs(args);
+            Assert.IsNull(config);
+        }
+
         [TestCase("path")]
         [TestCase("C:\\foo")]
         [TestCase("C:\\foo\\*.sql")]

--- a/Tests/SqlGenerationTests.cs
+++ b/Tests/SqlGenerationTests.cs
@@ -127,6 +127,68 @@ namespace Badgie.Migrator.Tests
         }
 
         [Test]
+        public void Postgres_TableCreationStatement_UsesCustomSchema()
+        {
+            var config = new Config { SqlType = SqlType.Postgres, Schema = "scheduler" };
+            var sql = GetTableCreationStatement(config);
+
+            Assert.IsNotNull(sql);
+            Assert.IsTrue(sql.Contains(@"CREATE SEQUENCE ""scheduler"".""MigrationRuns_Id_seq"""));
+            Assert.IsTrue(sql.Contains(@"CREATE TABLE ""scheduler"".MigrationRuns"));
+            Assert.IsFalse(sql.Contains(@"""public"""));
+        }
+
+        [Test]
+        public void SqlServer_TableCreationStatement_UsesCustomSchema()
+        {
+            var config = new Config { SqlType = SqlType.SqlServer, Schema = "myschema" };
+            var sql = GetTableCreationStatement(config);
+
+            Assert.IsNotNull(sql);
+            Assert.IsTrue(sql.Contains("CREATE TABLE [myschema].[MigrationRuns]"));
+            Assert.IsFalse(sql.Contains("[dbo]"));
+        }
+
+        [Test]
+        public void MySql_TableCreationStatement_UsesCustomSchema()
+        {
+            var config = new Config { SqlType = SqlType.MySql, Schema = "mydb" };
+            var sql = GetTableCreationStatement(config);
+
+            Assert.IsNotNull(sql);
+            Assert.IsTrue(sql.Contains("`mydb`.`migration_runs`"));
+        }
+
+        [Test]
+        public void SQLite_TableCreationStatement_UsesCustomSchema()
+        {
+            var config = new Config { SqlType = SqlType.SQLite, Schema = "attached" };
+            var sql = GetTableCreationStatement(config);
+
+            Assert.IsNotNull(sql);
+            Assert.IsTrue(sql.Contains("CREATE TABLE attached.MigrationRuns"));
+        }
+
+        [Test]
+        public void Postgres_TableCreationStatement_DefaultSchema_MatchesOriginal()
+        {
+            var config = new Config { SqlType = SqlType.Postgres };
+            var sql = GetTableCreationStatement(config);
+
+            Assert.IsTrue(sql.Contains(@"CREATE TABLE ""public"".MigrationRuns"));
+            Assert.IsTrue(sql.Contains("CREATE SEQUENCE MigrationRuns_Id_seq"));
+        }
+
+        [Test]
+        public void SqlServer_TableCreationStatement_DefaultSchema_MatchesOriginal()
+        {
+            var config = new Config { SqlType = SqlType.SqlServer };
+            var sql = GetTableCreationStatement(config);
+
+            Assert.IsTrue(sql.Contains("CREATE TABLE [dbo].[MigrationRuns]"));
+        }
+
+        [Test]
         public void AllDatabases_HaveMatchingColumnCount()
         {
             // Each database should define exactly 5 columns


### PR DESCRIPTION
## Summary

The migration tracking table (MigrationRuns/migration_runs) location was hardcoded to `public` (Postgres), `dbo` (SQL Server), and `main` (SQLite). This caused failures when using a non-default schema via the connection string's Search Path — `EnsureTableExists` would find the table in the default schema, but `ExecuteMigration` queries would look in the connection's schema and fail with "relation does not exist".

## Changes

- New `-s:<schema>` CLI parameter and `Schema` config property
- `EnsureTableExists`, `TableCreationStatement`, and all `ExecuteMigration` queries now use the specified schema across all four database types (Postgres, SQL Server, MySQL, SQLite)
- When `-s` is not specified, a deprecation warning is emitted. In a future version, `-s` will be required
- Updated help text to document the new parameter and include SQLite in database type listings
- Added tests for schema parameter parsing and custom schema SQL generation

## Test plan

- [x] All 128 existing + new tests pass on net8.0 and net10.0
- [ ] Integration test: run migrator with `-s:scheduler -i` against a Postgres database with a `scheduler` schema
- [ ] Integration test: run migrator with `-s:myschema -i` against SQL Server with a custom schema